### PR TITLE
Ensure isCrawler always returns boolean

### DIFF
--- a/src/lib/crawler.js
+++ b/src/lib/crawler.js
@@ -128,7 +128,7 @@ class Crawler
 			this.matches = matches;
 		}
 		
-		return matches !== null ? (matches.length ? true : false) : {};
+		return matches !== null ? (matches.length ? true : false) : false;
 	}
 
 	/**


### PR DESCRIPTION
`isCrawler` should always return a boolean value.

`{}` evaluates to `true` and it was causing issues for me.