### PR TITLE
Fix preparing userAgents from headers

### DIFF
--- a/src/lib/crawler.js
+++ b/src/lib/crawler.js
@@ -69,10 +69,13 @@ class Crawler {
       userAgent === null ||
       !userAgent.length
     ) {
-      userAgent = this.getUaHttpHeaders()
-        .map((header) => this.httpHeaders[header.toLowerCase()] || '')
-        .filter((userAgentHeader) => userAgentHeader.length > 0)
-        .join(' ');
+      userAgent = '';
+      for (const header of this.getUaHttpHeaders()) {
+        if (Object.keys(this.httpHeaders).indexOf(header.toLowerCase()) >= 0) {
+          const separator = userAgent.length > 0 ? ' ' : '';
+          userAgent += separator + this.httpHeaders[header.toLowerCase()];
+        }
+      }
     }
 
     return userAgent;

--- a/src/lib/crawler.js
+++ b/src/lib/crawler.js
@@ -69,11 +69,10 @@ class Crawler {
       userAgent === null ||
       !userAgent.length
     ) {
-      for (const header of this.getUaHttpHeaders()) {
-        if (Object.keys(this.httpHeaders).indexOf(header.toLowerCase()) >= 0) {
-          userAgent += this.httpHeaders[header.toLowerCase()] + ' ';
-        }
-      }
+      userAgent = this.getUaHttpHeaders()
+        .map((header) => this.httpHeaders[header.toLowerCase()] || '')
+        .filter((userAgentHeader) => userAgentHeader.length > 0)
+        .join(' ');
     }
 
     return userAgent;

--- a/test/lib/crawler.test.js
+++ b/test/lib/crawler.test.js
@@ -90,5 +90,13 @@ describe('crawler', () => {
 
       assert.strictEqual(crawler.isCrawler(), true);
     });
+
+    it('should identify the crawler from request headers with exact pattern', async () => {
+      crawler = new Crawler({
+        headers: { 'user-agent': 'b0t', accept: '*/*' },
+      });
+
+      assert.strictEqual(crawler.isCrawler(), true);
+    });
   });
 });

--- a/test/lib/crawler.test.js
+++ b/test/lib/crawler.test.js
@@ -98,5 +98,13 @@ describe('crawler', () => {
 
       assert.strictEqual(crawler.isCrawler(), true);
     });
+
+    it('should do not throw an exception on empty request header', async () => {
+      crawler = new Crawler({
+        headers: { accept: '*/*' },
+      });
+
+      assert.doesNotThrow(() => crawler.isCrawler());
+    });
   });
 });


### PR DESCRIPTION
User agent string gets `undefined` in front and space after, when user agent getting from headers on create crawler detector instance.  For example `'user-agent': 'b0t'` goes to `undefinedb0t `